### PR TITLE
Fix nested activity value parsing in notification extraction

### DIFF
--- a/src/core/client.py
+++ b/src/core/client.py
@@ -274,7 +274,8 @@ class NotionClient:
         # Find all export-completed activities after enqueued_at
         matching_activities = []
         for activity_data in notifications.get("recordMap", {}).get("activity", {}).values():
-            activity_value = activity_data.get("value", {})
+            # Activity data is nested: activity_data['value']['value']
+            activity_value = activity_data.get("value", {}).get("value", {})
             if activity_value.get("type") == "export-completed":
                 try:
                     activity_timestamp = int(activity_value.get("start_time", 0))


### PR DESCRIPTION
## Problem
   The Notion API returns activity data with a nested structure:
   ```python
   activity_data['value']['value']['type']
   ```

   Previously the code only accessed one level:
   ```python
   activity_data['value']['type']
   ```

   This caused export-completed activities to not be found, resulting in backup failures with error:
   ```
   No matching export-completed activities found
   ```

   ## Fix
   Access the nested value correctly by chaining the `.get()` calls.

   ## Testing
   Tested locally with successful backup completion.