### PR TITLE
Fix: fetch notifications from notion.com so the export download link is found

### DIFF
--- a/src/core/client.py
+++ b/src/core/client.py
@@ -25,10 +25,12 @@ class NotionClient:
     API_VERSION = "v3"
     ENQUEUE_ENDPOINT = f"{BASE_URL}/{API_VERSION}/enqueueTask"
     GET_TASKS_ENDPOINT = f"{BASE_URL}/{API_VERSION}/getTasks"
-    # Notifications/inbox migrated to notion.com; the notion.so feed returns empty
-    # for accounts whose session lives on app.notion.com, so the export-completed
-    # download link is never found. Fetch notifications from notion.com instead.
-    # Enqueue/getTasks still work on www.notion.so. See markhaines fork notes.
+    # Notifications/inbox moved to app.notion.com after Notion's notion.com
+    # migration: getNotificationLogV2 on www.notion.so returns an empty feed for
+    # accounts whose session lives on app.notion.com, so the export-completed
+    # activity that carries the download link is never found. Fetch notifications
+    # and mark-read from app.notion.com instead; enqueue/getTasks still work on
+    # www.notion.so.
     NOTIFICATION_BASE = "https://app.notion.com/api"
     NOTIFICATION_ENDPOINT = f"{NOTIFICATION_BASE}/{API_VERSION}/getNotificationLogV2"
     MARK_READ_ENDPOINT = f"{NOTIFICATION_BASE}/{API_VERSION}/saveTransactionsMain"

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -25,8 +25,13 @@ class NotionClient:
     API_VERSION = "v3"
     ENQUEUE_ENDPOINT = f"{BASE_URL}/{API_VERSION}/enqueueTask"
     GET_TASKS_ENDPOINT = f"{BASE_URL}/{API_VERSION}/getTasks"
-    NOTIFICATION_ENDPOINT = f"{BASE_URL}/{API_VERSION}/getNotificationLogV2"
-    MARK_READ_ENDPOINT = f"{BASE_URL}/{API_VERSION}/saveTransactionsMain"
+    # Notifications/inbox migrated to notion.com; the notion.so feed returns empty
+    # for accounts whose session lives on app.notion.com, so the export-completed
+    # download link is never found. Fetch notifications from notion.com instead.
+    # Enqueue/getTasks still work on www.notion.so. See markhaines fork notes.
+    NOTIFICATION_BASE = "https://app.notion.com/api"
+    NOTIFICATION_ENDPOINT = f"{NOTIFICATION_BASE}/{API_VERSION}/getNotificationLogV2"
+    MARK_READ_ENDPOINT = f"{NOTIFICATION_BASE}/{API_VERSION}/saveTransactionsMain"
     CONTENT_TYPE = "application/json"
 
     TOKEN_V2 = "token_v2"  # noqa: S105


### PR DESCRIPTION
## Problem

On accounts whose Notion session has migrated to **notion.com**, every backup fails at:

```
WARNING  No matching export-completed activities found
ERROR    Failed to extract download URL
```

The export itself succeeds (`enqueueTask` → `getTasks` returns `state: success`), but the download link can't be found. `getTasks` no longer returns the URL, so the tool falls back to polling `getNotificationLogV2` for the `export-completed` activity that carries the signed link — and that feed is **empty** when queried at `www.notion.so`.

## Root cause

Notion's notification/inbox feed is served from **`app.notion.com`** after the notion.com migration. `https://www.notion.so/api/v3/getNotificationLogV2` returns an empty `recordMap` (HTTP 200, `notificationIds: []`) for these accounts, so the activity is never found. `enqueueTask`/`getTasks` still work on `www.notion.so`.

Verified directly: same cookies, same body — `www.notion.so` returns 0 activities, `app.notion.com` returns the `export-completed` activity with `edits[0].link` set.

## Fix

Point `NOTIFICATION_ENDPOINT` and `MARK_READ_ENDPOINT` at `app.notion.com` (new `NOTIFICATION_BASE`), leaving enqueue/getTasks on `www.notion.so`. One small, isolated change.

## Notes

- Notification propagation can lag the export by tens of seconds (and minutes if many exports fire in quick succession — Notion appears to coalesce), so this pairs best with a generous `MAX_RETRIES`/`RETRY_DELAY`.
- Tested end-to-end on a migrated account: export → notification → signed `file.notion.so` download (HTTP 200) → 1.3 GB workspace export written successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated notification system infrastructure to enhance reliability of notification retrieval and status tracking mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->