### PR TITLE
Retry download on 503, fix storage on FUSE mounts, add session resume

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,8 +70,10 @@ def cli(ctx: click.Context, debug: bool, dry_run: bool) -> None:
 
 
 @cli.command()
+@click.option("--resume", is_flag=True, help="Resume previous backup session without prompting")
+@click.option("--skip-resume", is_flag=True, help="Skip resume and start a fresh backup")
 @click.pass_context
-def backup(ctx: click.Context) -> None:
+def backup(ctx: click.Context, resume: bool, skip_resume: bool) -> None:
     """Run backup of Notion workspace."""
     settings = load_settings()
     dry_run = ctx.obj.get("dry_run", False)
@@ -86,7 +88,12 @@ def backup(ctx: click.Context) -> None:
     click.echo(f"📄 Export Type: {settings.export_type.value}")
     click.echo()
 
-    success = run_backup_sync(settings, dry_run=dry_run)
+    if resume and skip_resume:
+        click.echo("❌ Cannot use both --resume and --skip-resume.", err=True)
+        sys.exit(1)
+
+    resume_opt: bool | None = True if resume else (False if skip_resume else None)
+    success = run_backup_sync(settings, dry_run=dry_run, resume=resume_opt)
 
     if success:
         click.echo("✅ Backup completed successfully!")

--- a/src/core/backup.py
+++ b/src/core/backup.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import sys
 import tempfile
 import zipfile
 from pathlib import Path
@@ -125,11 +126,15 @@ Created in dry-run mode at {timestamp}.
             session = load_session()
             if session:
                 if resume is None:
-                    answer = await asyncio.to_thread(
-                        input,
-                        "A previous backup session was found. Resume it? [y/N]: ",
-                    )
-                    should_resume = answer.strip().lower() == "y"
+                    if not sys.stdin.isatty():
+                        logger.info("Non-interactive environment detected; starting fresh backup session")
+                        should_resume = False
+                    else:
+                        answer = await asyncio.to_thread(
+                            input,
+                            "A previous backup session was found. Resume it? [y/N]: ",
+                        )
+                        should_resume = answer.strip().lower() == "y"
                 else:
                     should_resume = resume
 
@@ -160,7 +165,8 @@ Created in dry-run mode at {timestamp}.
                     resume_started_at_ms=resume_started_at_ms,
                 )
                 if not backup_file:
-                    clear_session()
+                    if resume_task_id is not None:
+                        clear_session()
                     error_message = "Failed to export from Notion"
                     return False
 

--- a/src/core/backup.py
+++ b/src/core/backup.py
@@ -10,7 +10,7 @@ from typing import Any
 from src.config import Settings
 from src.notifiers import AbstractNotifier, AppriseNotifier
 from src.storage import AbstractStorage, LocalStorage, RcloneStorage
-from src.utils import format_file_size, get_timestamp_string
+from src.utils import clear_session, format_file_size, get_timestamp_string, load_session
 from src.utils.redis_client import RedisClient
 
 from .client import NotionClient
@@ -96,20 +96,50 @@ Created in dry-run mode at {timestamp}.
         notification_config = self.settings.get_notification_config()
         return AppriseNotifier(notification_config, logger)
 
-    async def run_backup(self, dry_run: bool = False) -> bool:
+    async def run_backup(
+        self,
+        dry_run: bool = False,
+        resume: bool | None = None,
+    ) -> bool:
         """
         Run the complete backup process.
+
+        Args:
+            dry_run: If True, skip Notion export and use a dummy file
+            resume: None=prompt if session exists, True=auto-resume, False=skip resume
 
         Returns
         -------
             True if backup was successful, False otherwise
         """
         error_message = None
+        resume_task_id: str | None = None
+        resume_started_at_ms: int | None = None
 
         try:
             logger.info("=" * 60)
             logger.info("Starting Notion Backup Process")
             logger.info("=" * 60)
+
+            # Check for resumable session
+            session = load_session()
+            if session:
+                if resume is None:
+                    answer = await asyncio.to_thread(
+                        input,
+                        "A previous backup session was found. Resume it? [y/N]: ",
+                    )
+                    should_resume = answer.strip().lower() == "y"
+                else:
+                    should_resume = resume
+
+                if should_resume:
+                    logger.info("Resuming previous backup session for task %s", session["task_id"])
+                    resume_task_id = session["task_id"]
+                    resume_started_at_ms = session["export_started_at_ms"]
+                else:
+                    logger.info("Starting fresh backup session")
+                    clear_session()
 
             # Test connections first
             await self._test_connections(dry_run=dry_run)
@@ -123,8 +153,14 @@ Created in dry-run mode at {timestamp}.
                 temp_path = Path(temp_dir)
 
                 # Step 1: Export from Notion
-                backup_file = await self._handle_export(temp_path, dry_run)
+                backup_file = await self._handle_export(
+                    temp_path,
+                    dry_run,
+                    resume_task_id=resume_task_id,
+                    resume_started_at_ms=resume_started_at_ms,
+                )
                 if not backup_file:
+                    clear_session()
                     error_message = "Failed to export from Notion"
                     return False
 
@@ -145,6 +181,9 @@ Created in dry-run mode at {timestamp}.
 
                 # Step 3: Cleanup old backups
                 await self._handle_cleanup()
+
+                # Clear session on success
+                clear_session()
 
                 # Send success notification
                 await self._send_success_notification(
@@ -294,7 +333,13 @@ Created in dry-run mode at {timestamp}.
         else:
             logger.error("Task %s failed recovery after %d attempts, discarding", task_id, max_retries)
 
-    async def _handle_export(self, temp_path: Path, dry_run: bool) -> Path | None:
+    async def _handle_export(
+        self,
+        temp_path: Path,
+        dry_run: bool,
+        resume_task_id: str | None = None,
+        resume_started_at_ms: int | None = None,
+    ) -> Path | None:
         """Handle the export process and return the backup file path."""
         backup_file: Path | None = None
 
@@ -303,7 +348,11 @@ Created in dry-run mode at {timestamp}.
             backup_file = self._create_dummy_export(temp_path)
         else:
             logger.info("Step 1: Exporting from Notion...")
-            backup_file = await self.notion_client.export_workspace(temp_path)
+            backup_file = await self.notion_client.export_workspace(
+                temp_path,
+                resume_task_id=resume_task_id,
+                resume_started_at_ms=resume_started_at_ms,
+            )
 
             if not backup_file:
                 logger.error("Failed to export from Notion")
@@ -461,11 +510,15 @@ Created in dry-run mode at {timestamp}.
 
 
 # Synchronous wrapper for async operations
-def run_backup_sync(settings: Settings, dry_run: bool = False) -> bool:
+def run_backup_sync(
+    settings: Settings,
+    dry_run: bool = False,
+    resume: bool | None = None,
+) -> bool:
     """Run backup synchronously (wrapper for async operation)."""
     try:
         manager = BackupManager(settings)
-        return asyncio.run(manager.run_backup(dry_run=dry_run))
+        return asyncio.run(manager.run_backup(dry_run=dry_run, resume=resume))
     except Exception:
         logger.exception("Failed to run backup")
         return False

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -11,7 +11,7 @@ from typing import Any
 import requests
 
 from src.config import Settings
-from src.utils import get_timestamp_string, retry_async
+from src.utils import get_timestamp_string, retry_async, save_session
 from src.utils.redis_client import RedisClient
 
 logger = logging.getLogger(__name__)
@@ -52,29 +52,42 @@ class NotionClient:
         logger.info("Notion client initialized")
 
     @retry_async(max_retries=3, delay=5.0)
-    async def export_workspace(self, temp_dir: Path) -> Path | None:
+    async def export_workspace(
+        self,
+        temp_dir: Path,
+        resume_task_id: str | None = None,
+        resume_started_at_ms: int | None = None,
+    ) -> Path | None:
         """
         Export the Notion workspace and return the path to the downloaded file.
 
         Args:
             temp_dir: Temporary directory for download
+            resume_task_id: If set, skip triggering a new export and resume this task
+            resume_started_at_ms: Wall-clock time (ms) the original export was started
 
         Returns
         -------
             Path to the downloaded file or None if failed
         """
         try:
-            # Record wall-clock time (ms) before triggering export so we can
-            # filter out stale notifications that predate this export run.
-            export_started_at_ms = int(time.time() * 1000)
+            if resume_task_id and resume_started_at_ms:
+                logger.info("Resuming previous export session for task %s", resume_task_id)
+                task_id = resume_task_id
+                export_started_at_ms = resume_started_at_ms
+            else:
+                # Record wall-clock time (ms) before triggering export so we can
+                # filter out stale notifications that predate this export run.
+                export_started_at_ms = int(time.time() * 1000)
 
-            # Phase 1: Trigger export task
-            task_id = await self._trigger_export_task()
-            if not task_id:
-                logger.error("Failed to trigger export task")
-                return None
+                # Phase 1: Trigger export task
+                task_id = await self._trigger_export_task()
+                if not task_id:
+                    logger.error("Failed to trigger export task")
+                    return None
 
-            logger.debug("Export task triggered successfully with task ID: %s", task_id)
+                logger.debug("Export task triggered successfully with task ID: %s", task_id)
+                save_session(task_id, export_started_at_ms)
 
             # Phase 2: Poll for task completion (returns True on success)
             task_succeeded = await self._poll_task_completion(task_id)
@@ -368,50 +381,68 @@ class NotionClient:
         return None
 
     async def _download_file(self, download_url: str, temp_dir: Path) -> Path | None:
-        """Download the export file."""
-        try:
-            headers = {"Cookie": f"{self.FILE_TOKEN}={self.settings.notion_file_token.get_secret_value()}"}
+        """Download the export file with retry for transient errors."""
+        headers = {"Cookie": f"{self.FILE_TOKEN}={self.settings.notion_file_token.get_secret_value()}"}
 
-            # Generate filename
-            timestamp = get_timestamp_string()
-            flattened_suffix = "-flattened" if self.settings.flatten_export_filetree else ""
-            filename = f"notion-export-{self.settings.export_type.value}{flattened_suffix}_{timestamp}.zip"
+        timestamp = get_timestamp_string()
+        flattened_suffix = "-flattened" if self.settings.flatten_export_filetree else ""
+        filename = f"notion-export-{self.settings.export_type.value}{flattened_suffix}_{timestamp}.zip"
 
-            file_path = temp_dir / filename
+        file_path = temp_dir / filename
 
-            logger.info("Downloading export file: %s", filename)
+        max_retries = self.settings.max_retries
+        base_delay = self.settings.retry_delay
+        max_delay = self.settings.max_retry_delay
 
-            response = self.session.get(
-                download_url,
-                stream=True,
-                headers=headers,
-                timeout=self.settings.download_timeout,
-            )
-            response.raise_for_status()
+        for attempt in range(max_retries):
+            try:
+                logger.info("Downloading export file: %s (attempt %d/%d)", filename, attempt + 1, max_retries)
 
-            # Download with progress
-            total_size = int(response.headers.get("content-length", 0))
-            downloaded = 0
+                response = self.session.get(
+                    download_url,
+                    stream=True,
+                    headers=headers,
+                    timeout=self.settings.download_timeout,
+                )
+                response.raise_for_status()
 
-            with file_path.open("wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        f.write(chunk)
-                        downloaded += len(chunk)
+                total_size = int(response.headers.get("content-length", 0))
+                downloaded = 0
 
-                        # Log progress every 10MB
-                        if downloaded % (10 * 1024 * 1024) == 0 and total_size > 0:
-                            progress = (downloaded / total_size) * 100
-                            logger.debug("Download progress: %.1f%% (%d/%d bytes)", progress, downloaded, total_size)
+                with file_path.open("wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                            downloaded += len(chunk)
 
-            file_size = file_path.stat().st_size
-            logger.info("Download completed: %s (%d bytes)", filename, file_size)
+                            if downloaded % (10 * 1024 * 1024) == 0 and total_size > 0:
+                                progress = (downloaded / total_size) * 100
+                                logger.debug("Download progress: %.1f%% (%d/%d bytes)", progress, downloaded, total_size)
 
-        except Exception:
-            logger.exception("Failed to download file")
-            return None
-        else:
-            return file_path
+                file_size = file_path.stat().st_size
+                logger.info("Download completed: %s (%d bytes)", filename, file_size)
+                return file_path
+
+            except requests.HTTPError as e:
+                if attempt < max_retries - 1 and e.response is not None and e.response.status_code >= 500:
+                    delay = min(base_delay * (2 ** attempt), max_delay)
+                    logger.warning(
+                        "Download failed with HTTP %d (attempt %d/%d), retrying in %ds",
+                        e.response.status_code,
+                        attempt + 1,
+                        max_retries,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.exception("Failed to download file")
+                    return None
+
+            except Exception:
+                logger.exception("Failed to download file")
+                return None
+
+        return None
 
     async def _update_notification(self, args: dict[str, Any], debug_action: str) -> bool:
         if not self.export_notification_id:

--- a/src/storage/local.py
+++ b/src/storage/local.py
@@ -36,8 +36,8 @@ class LocalStorage(AbstractStorage):
             dest_name = destination_name or file_path.name
             dest_path = self.path / dest_name
 
-            # Copy file
-            shutil.copy2(file_path, dest_path)
+            # Copy file (use copyfile to avoid copymode/copystat on FUSE mounts)
+            shutil.copyfile(file_path, dest_path)
             file_size = dest_path.stat().st_size
 
             self.log("info", f"File stored locally at: {dest_path}")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,19 @@
 """Utility functions for Notion Backup."""
 
-from .helpers import format_file_size, get_timestamp_string, retry_async
+from .helpers import (
+    clear_session,
+    format_file_size,
+    get_timestamp_string,
+    load_session,
+    retry_async,
+    save_session,
+)
 
-__all__ = ["format_file_size", "get_timestamp_string", "retry_async"]
+__all__ = [
+    "clear_session",
+    "format_file_size",
+    "get_timestamp_string",
+    "load_session",
+    "retry_async",
+    "save_session",
+]

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -2,8 +2,11 @@
 
 import asyncio
 import functools
+import json
+import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, TypeVar
 
 T = TypeVar("T")
@@ -89,3 +92,40 @@ def truncate_string(text: str, max_length: int = 100, suffix: str = "...") -> st
     if len(text) <= max_length:
         return text
     return text[: max_length - len(suffix)] + suffix
+
+
+SESSION_FILE = Path.home() / ".notion-resume.json"
+
+
+def save_session(task_id: str, started_at_ms: int) -> None:
+    """Save export session state for resumption."""
+    data = {"task_id": task_id, "export_started_at_ms": started_at_ms}
+    SESSION_FILE.write_text(json.dumps(data, indent=2))
+    logging.getLogger(__name__).info("Session saved for task %s", task_id)
+
+
+def load_session() -> dict[str, Any] | None:
+    """Load saved session state, if any."""
+    if not SESSION_FILE.exists():
+        return None
+    try:
+        data = json.loads(SESSION_FILE.read_text())
+        task_id = data.get("task_id")
+        started_at_ms = data.get("export_started_at_ms")
+        if task_id and started_at_ms:
+            return {"task_id": task_id, "export_started_at_ms": started_at_ms}
+        clear_session()
+        return None
+    except (json.JSONDecodeError, OSError):
+        clear_session()
+        return None
+
+
+def clear_session() -> None:
+    """Clear the saved session state."""
+    try:
+        if SESSION_FILE.exists():
+            SESSION_FILE.unlink()
+            logging.getLogger(__name__).info("Session cleared")
+    except OSError:
+        pass

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -100,7 +100,11 @@ SESSION_FILE = Path.home() / ".notion-resume.json"
 def save_session(task_id: str, started_at_ms: int) -> None:
     """Save export session state for resumption."""
     data = {"task_id": task_id, "export_started_at_ms": started_at_ms}
-    SESSION_FILE.write_text(json.dumps(data, indent=2))
+    try:
+        SESSION_FILE.write_text(json.dumps(data, indent=2))
+    except OSError as e:
+        logging.getLogger(__name__).warning("Failed to persist resume session: %s", e)
+        return
     logging.getLogger(__name__).info("Session saved for task %s", task_id)
 
 


### PR DESCRIPTION
I dropped this into opencode with Deepseek to fix some issues I was facing.

1. The download URL was taking longer to show up on my account, so I extended the retry time and check for 5xx  errors.
2. Writing to Google Drive FUSE wasn't possible due to method attempting to copy metadata, removed this.
3. If anything happened during the session, it couldn't be resumed and would request another export, implemented a session save/resume.

Do as you wish with this pull-request. If you want anything changed I can do it. But ultimately this gave me a working method to do weekly notion backups in the background.

==

## 1. Retry download on transient Notion CDN errors (503)

**Problem:** When Notion's CDN returned a 503 Service Temporarily Unavailable during export file download, `_download_file()` immediately failed without retrying, aborting the entire backup. This was a transient error that a simple retry would resolve.

**Fix:** Wrapped the download request in a retry loop that catches HTTP 5xx responses and retries with exponential backoff (`base_delay * 2^attempt`, capped at `max_retry_delay`), matching the retry pattern already used elsewhere in the codebase. Non-HTTP exceptions (connection errors, timeouts) still fail immediately.

**File:** `src/core/client.py`

---

## 2. Fix file storage on FUSE-mounted filesystems (Google Drive)

**Problem:** Backups stored to a Google Drive mount (`/mnt/g/...`) failed with `[Errno 1] Operation not permitted`. The `shutil.copy2()` call attempted to copy file metadata (permissions, timestamps) via `copystat`, which the FUSE driver rejected.

**Fix:** Replaced `shutil.copy2` with `shutil.copyfile`, which copies file data only — no metadata operations. This is compatible with any filesystem, including FUSE mounts, network drives, and exotic local filesystems.

**File:** `src/storage/local.py`

---

## 3. Resume interrupted backup sessions

**Problem:** If the script failed while polling for the download URL (Phase 3) or during the download itself (Phase 4), the next run would trigger a brand new Notion export. This was wasteful — Notion exports can take 5+ minutes to generate, and triggering a new one on every retry could result in rate limiting or export queue congestion.

**Fix:** Added a session save/resume system:

- **Session file** at `~/.notion-resume.json` stores the `task_id` and `export_started_at_ms` after a new export task is successfully triggered (Phase 1 completes)
- **On next startup**, if a session file exists, the user is prompted: "Resume previous backup session? [y/N]"
- **CLI flags** `--resume` (auto-resume) and `--skip-resume` (start fresh) allow non-interactive use
- **Session is cleared** on successful completion or if the resume attempt itself fails (no infinite loops)
- **Resume flow** skips Phase 1 entirely, starting directly at Phase 2 (poll task completion), then proceeds through notification polling and download
- Works independently of the existing Redis-based recovery mechanism (which requires configured Redis)

**Files:** `src/utils/helpers.py`, `src/utils/__init__.py`, `src/core/client.py`, `src/core/backup.py`, `main.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--resume` and `--skip-resume` flags to the backup command to control how interrupted backups are continued.
  * Backup now persists export session details so interrupted exports can resume instead of restarting.

* **Bug Fixes**
  * The backup CLI now errors if both `--resume` and `--skip-resume` are provided together.

* **Improvements**
  * Improved download reliability with automatic retries for transient server failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->